### PR TITLE
Fix NaN value after Toon reboot

### DIFF
--- a/custom_components/toon_smartmeter/sensor.py
+++ b/custom_components/toon_smartmeter/sensor.py
@@ -152,7 +152,10 @@ class ToonSmartMeterSensor(Entity):
 
     def _validateOutput(self, value):
         """Return 0 if the output from the Toon is NaN (happens after a reboot)"""
-        return (0 if value == "NaN" else value)
+        if value.lower() == "nan":
+            return 0
+
+        return value
 
     @property
     def name(self):

--- a/custom_components/toon_smartmeter/sensor.py
+++ b/custom_components/toon_smartmeter/sensor.py
@@ -150,6 +150,10 @@ class ToonSmartMeterSensor(Entity):
         self._discovery = False
         self._dev_id = {}
 
+    def _validateOutput(self, value):
+        """Return 0 if the output from the Toon is NaN (happens after a reboot)"""
+        return (0 if value == "NaN" else value)
+
     @property
     def name(self):
         """Return the name of the sensor."""
@@ -222,87 +226,87 @@ class ToonSmartMeterSensor(Entity):
                 """elec verbruik puls"""
             elif self._type == 'elecusageflowpulse':
                 if 'dev_3.2' in energy:
-                    self._state = energy["dev_3.2"]["CurrentElectricityFlow"]
+                    self._state = self._validateOutput(energy["dev_3.2"]["CurrentElectricityFlow"])
                 elif 'dev_2.2' in energy:
-                    self._state = energy["dev_2.2"]["CurrentElectricityFlow"]
+                    self._state = self._validateOutput(energy["dev_2.2"]["CurrentElectricityFlow"])
                 elif 'dev_4.2' in energy:
-                    self._state = energy["dev_4.2"]["CurrentElectricityFlow"]
+                    self._state = self._validateOutput(energy["dev_4.2"]["CurrentElectricityFlow"])
                 elif 'dev_7.2' in energy:
-                    self._state = energy["dev_7.2"]["CurrentElectricityFlow"]
+                    self._state = self._validateOutput(energy["dev_7.2"]["CurrentElectricityFlow"])
 
                 """elec verbruik teller puls"""
             elif self._type == 'elecusagecntpulse':
                 if 'dev_3.2' in energy:
-                    self._state = float(energy["dev_3.2"]["CurrentElectricityQuantity"])/1000
+                    self._state = self._validateOutput(float(energy["dev_3.2"]["CurrentElectricityQuantity"])/1000)
                 elif 'dev_2.2' in energy:
-                    self._state = float(energy["dev_2.2"]["CurrentElectricityQuantity"])/1000
+                    self._state = self._validateOutput(float(energy["dev_2.2"]["CurrentElectricityQuantity"])/1000)
                 elif 'dev_4.2' in energy:
-                    self._state = float(energy["dev_4.2"]["CurrentElectricityQuantity"])/1000
+                    self._state = self._validateOutput(float(energy["dev_4.2"]["CurrentElectricityQuantity"])/1000)
                 elif 'dev_7.2' in energy:
-                    self._state = float(energy["dev_7.2"]["CurrentElectricityQuantity"])/1000
+                    self._state = self._validateOutput(float(energy["dev_7.2"]["CurrentElectricityQuantity"])/1000)
 
                 """elec verbruik laag"""
             elif self._type == 'elecusageflowlow':
                 if self._type in self._dev_id:
-                    self._state = energy[self._dev_id[self._type]]["CurrentElectricityFlow"]
+                    self._state = self._validateOutput(energy[self._dev_id[self._type]]["CurrentElectricityFlow"])
 
                 """elec verbruik teller laag"""
             elif self._type == 'elecusagecntlow':
                 if self._type in self._dev_id:
-                    self._state = float(energy[self._dev_id[self._type]]["CurrentElectricityQuantity"])/1000
+                    self._state = self._validateOutput(float(energy[self._dev_id[self._type]]["CurrentElectricityQuantity"])/1000)
 
                 """elec verbruik hoog/normaal"""
             elif self._type == 'elecusageflowhigh':
                 if self._type in self._dev_id:
-                    self._state = energy[self._dev_id[self._type]]["CurrentElectricityFlow"]
+                    self._state = self._validateOutput(energy[self._dev_id[self._type]]["CurrentElectricityFlow"])
 
                 """elec verbruik teller hoog/normaal"""
             elif self._type == 'elecusagecnthigh':
                 if self._type in self._dev_id:
-                    self._state = float(energy[self._dev_id[self._type]]["CurrentElectricityQuantity"])/1000
+                    self._state = self._validateOutput(float(energy[self._dev_id[self._type]]["CurrentElectricityQuantity"])/1000)
 
                 """elec teruglever laag"""
             elif self._type == 'elecprodflowlow':
                 if self._type in self._dev_id:
-                    self._state = energy[self._dev_id[self._type]]["CurrentElectricityFlow"]
+                    self._state = self._validateOutput(energy[self._dev_id[self._type]]["CurrentElectricityFlow"])
 
                 """elec teruglever teller laag"""
             elif self._type == 'elecprodcntlow':
                 if self._type in self._dev_id:
-                    self._state = float(energy[self._dev_id[self._type]]["CurrentElectricityQuantity"])/1000
+                    self._state = self._validateOutput(float(energy[self._dev_id[self._type]]["CurrentElectricityQuantity"])/1000)
 
                 """elec teruglever hoog/normaal"""
             elif self._type == 'elecprodflowhigh':
                 if self._type in self._dev_id:
-                    self._state = energy[self._dev_id[self._type]]["CurrentElectricityFlow"]
+                    self._state = self._validateOutput(energy[self._dev_id[self._type]]["CurrentElectricityFlow"])
 
                 """elec teruglever teller hoog/normaal"""
             elif self._type == 'elecprodcnthigh':
                 if self._type in self._dev_id:
-                    self._state = float(energy[self._dev_id[self._type]]["CurrentElectricityQuantity"])/1000
+                    self._state = self._validateOutput(float(energy[self._dev_id[self._type]]["CurrentElectricityQuantity"])/1000)
 
                 """zon op toon"""
             elif self._type == 'elecsolar':
                 if 'dev_2.3' in energy:
-                    self._state = energy["dev_2.3"]["CurrentElectricityFlow"]
+                    self._state = self._validateOutput(energy["dev_2.3"]["CurrentElectricityFlow"])
                 elif 'dev_3.3' in energy:
-                    self._state = energy["dev_3.3"]["CurrentElectricityFlow"]
+                    self._state = self._validateOutput(energy["dev_3.3"]["CurrentElectricityFlow"])
                 elif 'dev_4.3' in energy:
-                    self._state = energy["dev_4.3"]["CurrentElectricityFlow"]
+                    self._state = self._validateOutput(energy["dev_4.3"]["CurrentElectricityFlow"])
 
                 """zon op toon teller"""
             elif self._type == 'elecsolarcnt':
                 if 'dev_2.3' in energy:
-                    self._state = float(energy["dev_2.3"]["CurrentElectricityQuantity"])/1000
+                    self._state = self._validateOutput(float(energy["dev_2.3"]["CurrentElectricityQuantity"])/1000)
                 elif 'dev_3.3' in energy:
-                    self._state = float(energy["dev_3.3"]["CurrentElectricityQuantity"])/1000
+                    self._state = self._validateOutput(float(energy["dev_3.3"]["CurrentElectricityQuantity"])/1000)
                 elif 'dev_4.3' in energy:
-                    self._state = float(energy["dev_4.3"]["CurrentElectricityQuantity"])/1000
+                    self._state = self._validateOutput(float(energy["dev_4.3"]["CurrentElectricityQuantity"])/1000)
 
             elif self._type == 'heat':
                 if 'dev_2.8' in energy:
-                    self._state = float(energy["dev_2.8"]["CurrentHeatQuantity"])/1000
+                    self._state = self._validateOutput(float(energy["dev_2.8"]["CurrentHeatQuantity"])/1000)
                 elif 'dev_4.8' in energy:
-                    self._state = float(energy["dev_4.8"]["CurrentHeatQuantity"])/1000
+                    self._state = self._validateOutput(float(energy["dev_4.8"]["CurrentHeatQuantity"])/1000)
 
             _LOGGER.debug("Device: {} State: {}".format(self._type, self._state))


### PR DESCRIPTION
There seems to be a bug in the Toon that when the Toon has (re)booted, the values of energy production/consumption high or low are NaN (in the output from hdrv_zwave?action=getDevices.json) till they are changed again either by consuming or producing power during a low tariff period (if you rebooted it during high tariff period, or the other way around).

The use case where this is a problem is the following: I sum the low and high production/ consumption values to have one value for the production and one for the consumption. If one of them is NaN, then HA will add it up to NaN as well.

Fix? Validate every returned value and change it 0 if the value is indeed NaN.