### PR TITLE
Solar information from dev_3.export added

### DIFF
--- a/custom_components/toon_smartmeter/sensor.py
+++ b/custom_components/toon_smartmeter/sensor.py
@@ -293,7 +293,9 @@ class ToonSmartMeterSensor(Entity):
 
                 """zon op toon"""
             elif self._type == 'elecsolar':
-                if 'dev_2.3' in energy:
+                if 'dev_3.export' in energy:
+                    self._state = self._validateOutput(energy["dev_3.export"]["CurrentElectricityFlow"])
+                elif 'dev_2.3' in energy:
                     self._state = self._validateOutput(energy["dev_2.3"]["CurrentElectricityFlow"])
                 elif 'dev_3.3' in energy:
                     self._state = self._validateOutput(energy["dev_3.3"]["CurrentElectricityFlow"])
@@ -302,7 +304,9 @@ class ToonSmartMeterSensor(Entity):
 
                 """zon op toon teller"""
             elif self._type == 'elecsolarcnt':
-                if 'dev_2.3' in energy:
+                if 'dev_3.export' in energy:
+                    self._state = self._validateOutput(float(energy["dev_3.export"]["CurrentElectricityQuantity"])/1000)
+                elif 'dev_2.3' in energy:
                     self._state = self._validateOutput(float(energy["dev_2.3"]["CurrentElectricityQuantity"])/1000)
                 elif 'dev_3.3' in energy:
                     self._state = self._validateOutput(float(energy["dev_3.3"]["CurrentElectricityQuantity"])/1000)


### PR DESCRIPTION
My solar and solarcnt were not working, after debugging the JSON it appeared that my solar output is found under `dev_3.export`. I placed the device at the top as dev_2.3 was mentioned in the JSON but NaN.