### PR TITLE
Fix: object is not subscriptable error

### DIFF
--- a/custom_components/toon_smartmeter/sensor.py
+++ b/custom_components/toon_smartmeter/sensor.py
@@ -1,4 +1,5 @@
 """Sensor for Toon Smart Meter integration."""
+from __future__ import annotations
 
 import asyncio
 from datetime import timedelta
@@ -64,7 +65,7 @@ SENSOR_LIST = {
     "heat",
 }
 
-SENSOR_TYPES: Final[tuple[SensorEntityDescription]] = (
+SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
     SensorEntityDescription(
         key="gasused",
         name="Gas Used Last Hour",


### PR DESCRIPTION
This should fix the `File "/home/homeassistant/.homeassistant/custom_components/toon_smartmeter/sensor.py", line 66, in <module> SENSOR_TYPES: Final[tuple[SensorEntityDescription]] = ( TypeError: 'type' object is not subscriptable` error in Python `3.8`. (https://github.com/cyberjunky/home-assistant-toon_smartmeter/issues/23#issuecomment-894632983)

**Untested:** I have the same issue in Python, but not a Toon to actually test this.