### PR TITLE
Removing state_class total_increasing from power

### DIFF
--- a/custom_components/toon_smartmeter/sensor.py
+++ b/custom_components/toon_smartmeter/sensor.py
@@ -91,7 +91,6 @@ SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
         icon="mdi:flash",
         native_unit_of_measurement=POWER_WATT,
         device_class=DEVICE_CLASS_POWER,
-        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     SensorEntityDescription(
         key="elecusageflowhigh",
@@ -99,7 +98,6 @@ SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
         icon="mdi:flash",
         native_unit_of_measurement=POWER_WATT,
         device_class=DEVICE_CLASS_POWER,
-        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     SensorEntityDescription(
         key="elecprodflowlow",
@@ -107,7 +105,6 @@ SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
         icon="mdi:flash",
         native_unit_of_measurement=POWER_WATT,
         device_class=DEVICE_CLASS_POWER,
-        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     SensorEntityDescription(
         key="elecprodflowhigh",
@@ -115,7 +112,6 @@ SENSOR_TYPES: Final[tuple[SensorEntityDescription, ...]] = (
         icon="mdi:flash",
         native_unit_of_measurement=POWER_WATT,
         device_class=DEVICE_CLASS_POWER,
-        state_class=STATE_CLASS_TOTAL_INCREASING,
     ),
     SensorEntityDescription(
         key="elecusagecntpulse",


### PR DESCRIPTION
Power entities, (P1 Use/Prod low/high) should not contain the state_class STATE_CLASS_TOTAL_INCREASING since these sensors represent a measurement (current state) and not a total increasing value. This change fixes #34. Verified this change on my own production instance of Home Assistant.