### PR TITLE
Added dev_4.export to 'zon-op-toon' section

### DIFF
--- a/custom_components/toon_smartmeter/sensor.py
+++ b/custom_components/toon_smartmeter/sensor.py
@@ -498,7 +498,11 @@ class ToonSmartMeterSensor(SensorEntity):
 
             """zon op toon"""
         elif self._type == "elecsolar":
-            if "dev_3.export" in energy:
+            if "dev_4.export" in energy:
+                self._state = self._validateOutput(
+                    energy["dev_4.export"]["CurrentElectricityFlow"]
+                )
+            elif "dev_3.export" in energy:
                 self._state = self._validateOutput(
                     energy["dev_3.export"]["CurrentElectricityFlow"]
                 )
@@ -517,7 +521,11 @@ class ToonSmartMeterSensor(SensorEntity):
 
             """zon op toon teller"""
         elif self._type == "elecsolarcnt":
-            if "dev_3.export" in energy:
+            if "dev_4.export" in energy:
+                self._state = self._validateOutput(
+                    float(energy["dev_4.export"]["CurrentElectricityQuantity"]) / 1000
+                )
+            elif "dev_3.export" in energy:
                 self._state = self._validateOutput(
                     float(energy["dev_3.export"]["CurrentElectricityQuantity"]) / 1000
                 )


### PR DESCRIPTION
Added dev_4.export to 'zon-op-toon' section to support modern Qubino smart meters on old Toon V1 devices.