### PR TITLE
Fixed invalid data by replacing NaN with 0 in the JSON response

### DIFF
--- a/custom_components/toon_smartmeter/sensor.py
+++ b/custom_components/toon_smartmeter/sensor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import asyncio
 from datetime import timedelta
 from functools import reduce
+import json
 import logging
 from typing import Final
 
@@ -244,8 +245,9 @@ class ToonSmartMeterData(object):
             return
 
         try:
-            self._data = await response.json(content_type="text/javascript")
-            _LOGGER.debug("Data received from Toon: %s", self._data)
+            data = await response.text()
+            self._data = json.loads(data.replace("NaN", "0"))
+            _LOGGER.error("Data received from Toon: %s", self._data)
         except Exception as err:
             _LOGGER.error("Cannot parse data received from Toon: %s", err)
             self._data = None
@@ -278,16 +280,6 @@ class ToonSmartMeterSensor(SensorEntity):
 
         self._discovery = False
         self._dev_id = {}
-
-    def _validateOutput(self, value):
-        """Return 0 if the output from the Toon is NaN (happens after a reboot)"""
-        try:
-            if value.lower() == "nan":
-                value = 0    @property
-        except:
-            return value
-
-        return value
 
     @property
     def state(self):
@@ -421,163 +413,95 @@ class ToonSmartMeterSensor(SensorEntity):
             """gas verbruik laatste uur"""
         if self._type == "gasused":
             if self._type in self._dev_id:
-                self._state = (
-                    float(energy[self._dev_id[self._type]]["CurrentGasFlow"]) / 1000
-                )
+                self._state = (float(energy[self._dev_id[self._type]]["CurrentGasFlow"]) / 1000)
 
             """gas verbruik teller laatste uur"""
         elif self._type == "gasusedcnt":
             if self._type in self._dev_id:
-                self._state = (
-                    float(energy[self._dev_id[self._type]]["CurrentGasQuantity"]) / 1000
-                )
+                self._state = (float(energy[self._dev_id[self._type]]["CurrentGasQuantity"]) / 1000)
 
             """elec verbruik puls"""
         elif self._type == "elecusageflowpulse":
             if "dev_3.2" in energy:
-                self._state = self._validateOutput(
-                    energy["dev_3.2"]["CurrentElectricityFlow"]
-                )
+                self._state = energy["dev_3.2"]["CurrentElectricityFlow"]
             elif "dev_2.2" in energy:
-                self._state = self._validateOutput(
-                    energy["dev_2.2"]["CurrentElectricityFlow"]
-                )
+                self._state = energy["dev_2.2"]["CurrentElectricityFlow"]
             elif "dev_4.2" in energy:
-                self._state = self._validateOutput(
-                    energy["dev_4.2"]["CurrentElectricityFlow"]
-                )
+                self._state = energy["dev_4.2"]["CurrentElectricityFlow"]
             elif "dev_7.2" in energy:
-                self._state = self._validateOutput(
-                    energy["dev_7.2"]["CurrentElectricityFlow"]
-                )
+                self._state = energy["dev_7.2"]["CurrentElectricityFlow"]
 
             """elec verbruik teller puls"""
         elif self._type == "elecusagecntpulse":
             if "dev_3.2" in energy:
-                self._state = self._validateOutput(
-                    float(energy["dev_3.2"]["CurrentElectricityQuantity"]) / 1000
-                )
+                self._state = float(energy["dev_3.2"]["CurrentElectricityQuantity"]) / 1000
             elif "dev_2.2" in energy:
-                self._state = self._validateOutput(
-                    float(energy["dev_2.2"]["CurrentElectricityQuantity"]) / 1000
-                )
+                self._state = float(energy["dev_2.2"]["CurrentElectricityQuantity"]) / 1000
             elif "dev_4.2" in energy:
-                self._state = self._validateOutput(
-                    float(energy["dev_4.2"]["CurrentElectricityQuantity"]) / 1000
-                )
+                self._state = float(energy["dev_4.2"]["CurrentElectricityQuantity"]) / 1000
             elif "dev_7.2" in energy:
-                self._state = self._validateOutput(
-                    float(energy["dev_7.2"]["CurrentElectricityQuantity"]) / 1000
-                )
+                self._state = float(energy["dev_7.2"]["CurrentElectricityQuantity"]) / 1000
 
             """elec verbruik laag"""
         elif self._type == "elecusageflowlow":
             if self._type in self._dev_id:
-                self._state = self._validateOutput(
-                    energy[self._dev_id[self._type]]["CurrentElectricityFlow"]
-                )
+                self._state = energy[self._dev_id[self._type]]["CurrentElectricityFlow"]
 
             """elec verbruik teller laag"""
         elif self._type == "elecusagecntlow":
             if self._type in self._dev_id:
-                self._state = self._validateOutput(
-                    float(
-                        energy[self._dev_id[self._type]]["CurrentElectricityQuantity"]
-                    )
-                    / 1000
-                )
+                self._state = float(energy[self._dev_id[self._type]]["CurrentElectricityQuantity"])/ 1000
 
             """elec verbruik hoog/normaal"""
         elif self._type == "elecusageflowhigh":
             if self._type in self._dev_id:
-                self._state = self._validateOutput(
-                    energy[self._dev_id[self._type]]["CurrentElectricityFlow"]
-                )
+                self._state = energy[self._dev_id[self._type]]["CurrentElectricityFlow"]
 
             """elec verbruik teller hoog/normaal"""
         elif self._type == "elecusagecnthigh":
             if self._type in self._dev_id:
-                self._state = self._validateOutput(
-                    float(
-                        energy[self._dev_id[self._type]]["CurrentElectricityQuantity"]
-                    )
-                    / 1000
-                )
+                self._state = float(energy[self._dev_id[self._type]]["CurrentElectricityQuantity"]) / 1000
 
             """elec teruglever laag"""
         elif self._type == "elecprodflowlow":
             if self._type in self._dev_id:
-                self._state = self._validateOutput(
-                    energy[self._dev_id[self._type]]["CurrentElectricityFlow"]
-                )
+                self._state = energy[self._dev_id[self._type]]["CurrentElectricityFlow"]
 
             """elec teruglever teller laag"""
         elif self._type == "elecprodcntlow":
             if self._type in self._dev_id:
-                self._state = self._validateOutput(
-                    float(
-                        energy[self._dev_id[self._type]]["CurrentElectricityQuantity"]
-                    )
-                    / 1000
-                )
+                self._state = float(energy[self._dev_id[self._type]]["CurrentElectricityQuantity"])/ 1000
 
             """elec teruglever hoog/normaal"""
         elif self._type == "elecprodflowhigh":
             if self._type in self._dev_id:
-                self._state = self._validateOutput(
-                    energy[self._dev_id[self._type]]["CurrentElectricityFlow"]
-                )
+                self._state = energy[self._dev_id[self._type]]["CurrentElectricityFlow"]
 
             """elec teruglever teller hoog/normaal"""
         elif self._type == "elecprodcnthigh":
             if self._type in self._dev_id:
-                self._state = self._validateOutput(
-                    float(
-                        energy[self._dev_id[self._type]]["CurrentElectricityQuantity"]
-                    )
-                    / 1000
-                )
+                self._state = float(energy[self._dev_id[self._type]]["CurrentElectricityQuantity"]) / 1000
 
             """zon op toon"""
         elif self._type == "elecsolar":
             if "dev_4.export" in energy:
-                self._state = self._validateOutput(
-                    energy["dev_4.export"]["CurrentElectricityFlow"]
-                )
+                self._state = energy["dev_4.export"]["CurrentElectricityFlow"]
             elif "dev_3.export" in energy:
-                self._state = self._validateOutput(
-                    energy["dev_3.export"]["CurrentElectricityFlow"]
-                )
+                self._state = energy["dev_3.export"]["CurrentElectricityFlow"]
             elif self._type in self._dev_id:
-                self._state = self._validateOutput(
-                    energy[self._dev_id[self._type]]["CurrentElectricityFlow"]
-                )
+                self._state = energy[self._dev_id[self._type]]["CurrentElectricityFlow"]
             """zon op toon teller"""
         elif self._type == "elecsolarcnt":
             if "dev_4.export" in energy:
-                self._state = self._validateOutput(
-                    float(energy["dev_4.export"]["CurrentElectricityQuantity"]) / 1000
-                )
+                self._state = float(energy["dev_4.export"]["CurrentElectricityQuantity"]) / 1000
             elif "dev_3.export" in energy:
-                self._state = self._validateOutput(
-                    float(energy["dev_3.export"]["CurrentElectricityQuantity"]) / 1000
-                )
+                self._state = float(energy["dev_3.export"]["CurrentElectricityQuantity"]) / 1000
             elif self._type in self._dev_id:
-                self._state = self._validateOutput(
-                    float(
-                        energy[self._dev_id[self._type]]["CurrentElectricityQuantity"]
-                    )
-                    / 1000
-                )
+                self._state = float(energy[self._dev_id[self._type]]["CurrentElectricityQuantity"])/ 1000
 
         elif self._type == "heat":
             if self._type in self._dev_id:
-                self._state = self._validateOutput(
-                    float(
-                        energy[self._dev_id[self._type]]["CurrentHeatQuantity"]
-                    )
-                    / 1000
-                )
+                self._state = float(energy[self._dev_id[self._type]]["CurrentHeatQuantity"])/ 1000
 
         _LOGGER.debug("Device: {} State: {}".format(self._type, self._state))
 

--- a/custom_components/toon_smartmeter/sensor.py
+++ b/custom_components/toon_smartmeter/sensor.py
@@ -247,7 +247,7 @@ class ToonSmartMeterData(object):
         try:
             data = await response.text()
             self._data = json.loads(data.replace("NaN", "0"))
-            _LOGGER.error("Data received from Toon: %s", self._data)
+            _LOGGER.debug("Data received from Toon: %s", self._data)
         except Exception as err:
             _LOGGER.error("Cannot parse data received from Toon: %s", err)
             self._data = None


### PR DESCRIPTION
This is a follow-up of PR https://github.com/cyberjunky/home-assistant-toon_smartmeter/pull/11

The issue that NaN values were entering Home Assistant after a reboot of the Toon came back (probably due to the appearance of an additional @property tag in the validate function that broke the function). I've fixed it by replacing NaN values with 0's in the JSON response as you suggested in the previous PR.

I've tested it with my own Toon and two Home Assistant instances and seems to be running fine.