### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/toon_smartmeter/sensor.py
+++ b/custom_components/toon_smartmeter/sensor.py
@@ -380,6 +380,7 @@ class ToonSmartMeterSensor(SensorEntity):
                         "HAE_METER_v2_6",
                         "HAE_METER_v3_7",
                         "HAE_METER_v4_7",
+                        "HAE_METER_HEAT_6",
                     ]
                     and safe_get(
                         energy, [key, "CurrentElectricityQuantity"], default="NaN"
@@ -397,6 +398,7 @@ class ToonSmartMeterSensor(SensorEntity):
                         "HAE_METER_v2_4",
                         "HAE_METER_v3_5",
                         "HAE_METER_v4_5",
+                        "HAE_METER_HEAT_4",
                     ]
                     and safe_get(
                         energy, [key, "CurrentElectricityQuantity"], default="NaN"


### PR DESCRIPTION
Toon uses different sensor names when it is configured for city heating. I now have solar panels installed and could see the names for the meters  for "teruglevering laag" = "HAE_METER_HEAT_6",
en "teruglevering normaal" = "HAE_METER_HEAT_4"