### PR TITLE
Update readme for addressing syntax changes in configuration.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ template:
       default_entity_id: sensor.energie_verbruik_totaal
       icon: mdi:lightning-bolt
       name: Energieverbruik
-      state: '{{ states(''sensor.toon_p1_power_use_low'') | int + states(''sensor.toon_p1_power_use_high'') | int }}'
+      state: "{{ states('sensor.toon_p1_power_use_low') | int + states('sensor.toon_p1_power_use_high') | int }}"
 ```
 ### Calculate Gas used today
 ```


### PR DESCRIPTION
Hello, 

I recently got a warning from homeassistant in regards to a configuration snippet which originally came from here. The syntax is deprecated and becomes invalid with release 2026.6 according to the notice. So this MR attempts to fix this at its source. 